### PR TITLE
Add pytest-play plugin skeleton

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+pip install pytest-play
+
+pytest -q \
+  --yd yaml_test \
+  --env ci \
+  --file "$TEST_FILE" \
+  --junitxml  /results/junit-${TEST_FILE%.yaml}.xml \
+  --alluredir /results/allure-${TEST_FILE%.yaml}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "pytest-play"
+version = "0.1.0"
+dependencies = ["pytest>=7", "PyYAML"]
+
+[project.entry-points.pytest11]
+pytest_play = "pytest_play.conftest"

--- a/pytest_play/__init__.py
+++ b/pytest_play/__init__.py
@@ -1,0 +1,3 @@
+"""pytest-play plugin package"""
+
+__all__ = []

--- a/pytest_play/assertion.py
+++ b/pytest_play/assertion.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Iterable
+
+
+DEFAULT_TIMEOUT = 30
+DEFAULT_INTERVAL = 0.5
+
+
+def wait_until(cond, timeout=DEFAULT_TIMEOUT, interval=DEFAULT_INTERVAL):
+    end_time = time.time() + timeout
+    while time.time() < end_time:
+        if cond():
+            return True
+        time.sleep(interval)
+    return False
+
+
+def _get_attr(obj: Any, field: str):
+    for part in field.split('.'):
+        obj = getattr(obj, part)
+    return obj
+
+
+def check(assertions: Iterable[dict], ctx: Dict[str, Any]) -> None:
+    for a in assertions:
+        if a.get("type") == "state":
+            field = a["field"]
+            value = a["value"]
+            timeout = a.get("timeout", DEFAULT_TIMEOUT)
+            if not wait_until(lambda: _get_attr(ctx["robot_state"], field).name == value, timeout):
+                current = _get_attr(ctx["robot_state"], field).name
+                raise AssertionError(f"{field} expected {value}, got {current}")
+        else:
+            raise ValueError(f"unsupported assertion type: {a}")

--- a/pytest_play/conftest.py
+++ b/pytest_play/conftest.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from .parser import collect_all, collect_from_file, TestCase
+from .executor import ExecutionContext, run_steps
+from .assertion import check
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    group = parser.getgroup("pytest-play")
+    group.addoption("--yd", action="store", default="yaml_test", help="YAML directory")
+    group.addoption("--env", action="store", default="", help="env name")
+    group.addoption("--file", action="store", default="", help="specific yaml file")
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    if "case" in metafunc.fixturenames:
+        yd = Path(metafunc.config.getoption("--yd"))
+        file = metafunc.config.getoption("--file")
+        if file:
+            cases = [collect_from_file(yd / file)]
+        else:
+            cases = collect_all(yd)
+        metafunc.parametrize("case", cases, ids=[c.name for c in cases])
+
+
+@pytest.fixture
+def ctx() -> ExecutionContext:
+    return ExecutionContext(robot_state=None)
+
+
+def test_yaml_case(case: TestCase, ctx: ExecutionContext) -> None:
+    run_steps(case.steps, ctx)
+    if case.assertions:
+        check(case.assertions, ctx)

--- a/pytest_play/executor.py
+++ b/pytest_play/executor.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .registry import get_action
+
+
+class ExecutionContext(Dict[str, Any]):
+    pass
+
+
+def run_steps(steps: List[dict], ctx: ExecutionContext) -> None:
+    for step in steps:
+        if step.get("type") != "action":
+            raise ValueError(f"unsupported step type: {step}")
+        name = step["name"]
+        action = get_action(name)
+        params = step.get("params", {})
+        action(ctx, **params)

--- a/pytest_play/parser.py
+++ b/pytest_play/parser.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+import yaml
+
+
+@dataclass
+class TestCase:
+    name: str
+    steps: List[dict]
+    assertions: List[dict]
+    path: Path
+
+
+def collect_from_file(path: Path) -> TestCase:
+    data = yaml.safe_load(path.read_text()) or {}
+    name = data.get("test_name", path.stem)
+    steps = data.get("steps", [])
+    assertions = data.get("assertions", [])
+    return TestCase(name=name, steps=steps, assertions=assertions, path=path)
+
+
+def collect_all(directory: Path) -> List[TestCase]:
+    cases = []
+    for p in sorted(directory.glob("*.yaml")):
+        cases.append(collect_from_file(p))
+    return cases

--- a/pytest_play/registry.py
+++ b/pytest_play/registry.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from functools import wraps
+from typing import Callable, Dict
+
+
+_ACTIONS: Dict[str, Callable] = {}
+
+
+def step(name: str) -> Callable:
+    """Decorator to register an action function."""
+
+    def decorator(func: Callable) -> Callable:
+        _ACTIONS[name] = func
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def get_action(name: str) -> Callable:
+    if name not in _ACTIONS:
+        raise KeyError(f"unknown step: {name}")
+    return _ACTIONS[name]

--- a/pytest_play/tests/test_parser_executor.py
+++ b/pytest_play/tests/test_parser_executor.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from project.core.state import RobotState, StateType, WorkingStateType
+
+from pytest_play.parser import collect_from_file
+from pytest_play.executor import ExecutionContext, run_steps
+from pytest_play.assertion import check
+from pytest_play.registry import step
+
+
+def test_parser_and_executor(tmp_path: Path):
+    yaml_content = """
+    test_name: demo
+    steps:
+      - type: action
+        name: start
+    assertions:
+      - type: state
+        field: sub_status
+        value: WORKING_STATE_RUNNING
+        timeout: 1
+    """
+    yaml_file = tmp_path / "case.yaml"
+    yaml_file.write_text(yaml_content)
+
+    # register action
+    @step("start")
+    def start(ctx: ExecutionContext):
+        ctx["robot_state"] = RobotState(
+            status=StateType.STATE_WORK,
+            sub_status=WorkingStateType.WORKING_STATE_RUNNING,
+        )
+
+    case = collect_from_file(yaml_file)
+    ctx = ExecutionContext()
+    run_steps(case.steps, ctx)
+    check(case.assertions, ctx)

--- a/pytest_play/tests/test_registry.py
+++ b/pytest_play/tests/test_registry.py
@@ -1,0 +1,14 @@
+from pytest_play.registry import step, get_action
+
+
+def test_step_register_and_call():
+    calls = []
+
+    @step("hello")
+    def hello(ctx):
+        calls.append("called")
+
+    action = get_action("hello")
+    action({})
+
+    assert calls == ["called"]

--- a/yaml_test/test_mowing_global.yaml
+++ b/yaml_test/test_mowing_global.yaml
@@ -1,0 +1,21 @@
+test_name: 全局割草并回充
+
+steps:
+  - type: action
+    name: start_mowing_global
+
+assertions:
+  - type: state
+    field: sub_status
+    value: WORKING_STATE_RUNNING
+    timeout: 60
+
+steps:
+  - type: action
+    name: pause_and_dock
+
+assertions:
+  - type: state
+    field: dock_status
+    value: DOCK_SUCCESS
+    timeout: 120


### PR DESCRIPTION
## Summary
- implement pytest-play plugin modules (`parser`, `registry`, `executor`, `assertion`, `conftest`)
- add plugin tests and sample YAML
- provide packaging via `pyproject.toml`
- add docker entrypoint script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685f885c7d6c8332af4447a909e6b135