### PR TITLE
Implement pytest-play plugin

### DIFF
--- a/project/commands/__init__.py
+++ b/project/commands/__init__.py
@@ -1,3 +1,6 @@
 from .registry import send
 
+# import sample commands so that steps are registered when package is imported
+from . import sample
+
 __all__ = ["send"]

--- a/project/commands/sample.py
+++ b/project/commands/sample.py
@@ -1,0 +1,6 @@
+from pytest_play.registry import step
+
+
+@step("touch_state")
+def touch_state(ctx):
+    ctx["touched"] = "yes"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "pytest-play"
+version = "0.1.0"
+dependencies = ["pytest>=7", "PyYAML"]
+
+[project.entry-points.pytest11]
+pytest_play = "pytest_play.conftest"

--- a/pytest_play/README.md
+++ b/pytest_play/README.md
@@ -1,0 +1,6 @@
+# pytest-play
+
+A lightweight pytest plugin to run YAML-defined actions and assertions.
+
+This plugin demonstrates how YAML files can drive pytest test cases. It is a
+simplified implementation based on the project design document.

--- a/pytest_play/__init__.py
+++ b/pytest_play/__init__.py
@@ -1,0 +1,7 @@
+"""pytest-play plugin package."""
+
+# ensure plugin is discovered when installed
+
+def pytest_configure(config):
+    # this function intentionally empty to mark plugin as pytest plugin
+    pass

--- a/pytest_play/assertion.py
+++ b/pytest_play/assertion.py
@@ -1,0 +1,33 @@
+"""Simple assertion handlers for pytest-play."""
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Callable
+
+
+class TimeoutError(AssertionError):
+    pass
+
+
+def wait_until(predicate: Callable[[], bool], timeout: float) -> None:
+    start = time.time()
+    while time.time() - start < timeout:
+        if predicate():
+            return
+        time.sleep(0.1)
+    raise TimeoutError(f"condition not met within {timeout}s")
+
+
+def check(assertions, ctx: Dict[str, Any]) -> None:
+    for a in assertions:
+        if a["type"] == "state":
+            field = a["field"]
+            expect = a["value"]
+            timeout = a.get("timeout", 5)
+
+            def pred() -> bool:
+                return ctx.get(field) == expect
+
+            wait_until(pred, timeout)
+        else:
+            raise AssertionError(f"unknown assertion type: {a['type']}")

--- a/pytest_play/conftest.py
+++ b/pytest_play/conftest.py
@@ -1,0 +1,39 @@
+"""pytest plugin hooks for pytest-play."""
+from __future__ import annotations
+
+import pytest
+from pathlib import Path
+
+from . import parser, executor, assertion
+
+
+def pytest_addoption(parser):
+    parser.addoption("--yd", action="store", default="yaml_test", help="yaml dir")
+    parser.addoption("--env", action="store", default="local", help="env")
+    parser.addoption("--file", action="store", default="", help="yaml file")
+
+
+def pytest_generate_tests(metafunc):
+    if "case" not in metafunc.fixturenames:
+        return
+    yd = Path(metafunc.config.getoption("--yd"))
+    file = metafunc.config.getoption("--file")
+    if file:
+        paths = [yd / file]
+    else:
+        paths = list(yd.glob("*.yaml"))
+    cases = []
+    for p in paths:
+        cases.extend(parser.Parser(p.parent).parse_file(p))
+    ids = [c.name for c in cases]
+    metafunc.parametrize("case", cases, ids=ids)
+
+
+@pytest.fixture
+def ctx():
+    return executor.ExecutionContext()
+
+
+def test_yaml_case(case, ctx):
+    executor.run_steps(case.steps, ctx)
+    assertion.check(case.assertions, ctx)

--- a/pytest_play/executor.py
+++ b/pytest_play/executor.py
@@ -1,0 +1,19 @@
+"""Execute steps sequentially."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from . import registry
+
+
+class ExecutionContext(dict):
+    """Simple context to share data between steps."""
+
+
+def run_steps(steps, ctx: ExecutionContext) -> None:
+    for step in steps:
+        if step.get("type") != "action":
+            continue
+        name = step["name"]
+        func = registry.get(name)
+        func(ctx, **step.get("args", {}))

--- a/pytest_play/parser.py
+++ b/pytest_play/parser.py
@@ -1,0 +1,44 @@
+"""YAML parser for pytest-play."""
+
+from __future__ import annotations
+
+import yaml
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Dict, Any
+
+
+@dataclass
+class TestCase:
+    name: str
+    steps: List[Dict[str, Any]]
+    assertions: List[Dict[str, Any]]
+
+
+class Parser:
+    def __init__(self, base: Path):
+        self.base = Path(base)
+
+    def collect_all(self) -> List[TestCase]:
+        cases: List[TestCase] = []
+        for p in sorted(self.base.glob("*.yaml")):
+            cases.extend(self.parse_file(p))
+        return cases
+
+    def parse_file(self, path: Path) -> List[TestCase]:
+        content = yaml.safe_load(path.read_text("utf-8")) or {}
+        if isinstance(content, list):
+            datas = content
+        else:
+            datas = [content]
+        cases: List[TestCase] = []
+        for data in datas:
+            name = data.get("test_name", path.stem)
+            steps = data.get("steps", [])
+            assertions = data.get("assertions", [])
+            cases.append(TestCase(name=name, steps=steps, assertions=assertions))
+        return cases
+
+
+def collect_all(base: Path) -> List[TestCase]:
+    return Parser(base).collect_all()

--- a/pytest_play/registry.py
+++ b/pytest_play/registry.py
@@ -1,0 +1,26 @@
+"""Step registry for pytest-play."""
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+
+_REGISTRY: Dict[str, Callable[..., None]] = {}
+
+
+def step(name: str) -> Callable[[Callable[..., None]], Callable[..., None]]:
+    """Decorator to register a step function."""
+    def wrapper(func: Callable[..., None]) -> Callable[..., None]:
+        _REGISTRY[name] = func
+        return func
+
+    return wrapper
+
+
+def get(name: str) -> Callable[..., None]:
+    if name not in _REGISTRY:
+        raise KeyError(f"unknown step: {name}")
+    return _REGISTRY[name]
+
+
+def registry() -> Dict[str, Callable[..., None]]:
+    return dict(_REGISTRY)

--- a/pytest_play/tests/test_plugin.py
+++ b/pytest_play/tests/test_plugin.py
@@ -1,0 +1,24 @@
+import pytest
+from pathlib import Path
+
+from pytest_play import parser, registry, executor, assertion
+
+
+def test_parser_collect():
+    cases = parser.collect_all(Path(__file__).parent / "yaml")
+    assert cases
+    assert cases[0].name == "example"
+
+
+@registry.step("set_value")
+def set_value(ctx, key, value):
+    ctx[key] = value
+
+
+def test_run(tmp_path):
+    cases = parser.collect_all(Path(__file__).parent / "yaml")
+    case = cases[0]
+    ctx = executor.ExecutionContext()
+    executor.run_steps(case.steps, ctx)
+    assertion.check(case.assertions, ctx)
+    assert ctx["foo"] == "bar"

--- a/pytest_play/tests/yaml/test_example.yaml
+++ b/pytest_play/tests/yaml/test_example.yaml
@@ -1,0 +1,12 @@
+test_name: example
+steps:
+  - type: action
+    name: set_value
+    args:
+      key: foo
+      value: bar
+assertions:
+  - type: state
+    field: foo
+    value: bar
+    timeout: 1

--- a/yaml_test/test_sample.yaml
+++ b/yaml_test/test_sample.yaml
@@ -1,0 +1,9 @@
+test_name: sample
+steps:
+  - type: action
+    name: touch_state
+assertions:
+  - type: state
+    field: touched
+    value: yes
+    timeout: 1


### PR DESCRIPTION
## Summary
- implement a lightweight `pytest_play` plugin with parser, registry, executor and assertion helpers
- add pytest plugin hooks to generate tests from YAML
- provide pyproject entry points for plugin discovery
- include sample command and YAML test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685f885c7d6c8332af4447a909e6b135